### PR TITLE
fix: :wrench: change message and fix claim page

### DIFF
--- a/src/components/GeneratorCard/GeneratorCard.tsx
+++ b/src/components/GeneratorCard/GeneratorCard.tsx
@@ -70,7 +70,8 @@ function GeneratorCard() {
             setError(null);
 
             // 1. Sign the SHREDR message
-            const messageBytes = new TextEncoder().encode(MASTER_MESSAGE);
+            const message = `${MASTER_MESSAGE}:${publicKey.toBase58()}`;
+            const messageBytes = new TextEncoder().encode(message);
             const signature = await signMessage(messageBytes);
 
             setCardState('initializing');

--- a/src/pages/ClaimPage/ClaimPage.css
+++ b/src/pages/ClaimPage/ClaimPage.css
@@ -12,6 +12,7 @@
     padding: 2rem;
     max-width: 480px;
     width: 100%;
+    border: 1px solid #1a1a1a;
 }
 
 /* ========== HEADER ========== */
@@ -22,6 +23,15 @@
     margin-bottom: 2rem;
 }
 
+/* Center header when it's the only content (empty states) */
+.claim-header:only-child,
+.claim-message+.back-btn~.claim-header {
+    justify-content: center;
+}
+
+.claim-card>.claim-header+.claim-message {
+    /* When message follows header directly (empty states), center the header */
+}
 .claim-title {
     font-size: 1.5rem;
     font-weight: 700;
@@ -109,6 +119,36 @@
     opacity: 0.5;
 }
 
+/* ========== BURNER ADDRESS DISPLAY ========== */
+.burner-address-display {
+    text-align: center;
+    margin-bottom: 1.5rem;
+}
+
+.burner-address-display small {
+    color: #666666;
+    font-size: 0.75rem;
+    font-family: 'Space Mono', monospace;
+}
+
+/* ========== DESTINATION INFO (Read Only) ========== */
+.destination-info {
+    margin-bottom: 1.5rem;
+    padding: 1rem;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid #333333;
+}
+
+.destination-info .destination-label {
+    margin-bottom: 0.5rem;
+}
+
+.destination-value {
+    color: #e0e0e0;
+    font-family: 'Space Mono', monospace;
+    font-size: 0.8rem;
+    word-break: break-all;
+}
 /* ========== WITHDRAW BUTTON ========== */
 .withdraw-btn {
     width: 100%;

--- a/src/pages/ClaimPage/ClaimPage.tsx
+++ b/src/pages/ClaimPage/ClaimPage.tsx
@@ -1,5 +1,7 @@
+
 import { useState, useCallback, useEffect } from 'react';
-import { useWallet } from '@solana/wallet-adapter-react';
+import { useWallet, useConnection } from '@solana/wallet-adapter-react';
+import { SystemProgram, Transaction, PublicKey, LAMPORTS_PER_SOL, Keypair } from '@solana/web3.js';
 import { shredrClient } from '../../lib';
 import './ClaimPage.css';
 
@@ -8,31 +10,61 @@ interface ClaimPageProps {
 }
 
 function ClaimPage({ onBack }: ClaimPageProps) {
-    const { connected } = useWallet();
+    const { connected, publicKey, signMessage } = useWallet();
     
     // State
     const [totalBalance, setTotalBalance] = useState<number>(0);
-    const [destinationAddress, setDestinationAddress] = useState('');
     const [isWithdrawing, setIsWithdrawing] = useState(false);
     const [withdrawError, setWithdrawError] = useState<string | null>(null);
     const [withdrawSuccess, setWithdrawSuccess] = useState<string | null>(null);
+    const [isInitialized, setIsInitialized] = useState<boolean>(false);
+    const [isUnlocking, setIsUnlocking] = useState<boolean>(false);
+    const [isNewUser, setIsNewUser] = useState<boolean>(false);
 
     // ============ EFFECTS ============
 
     useEffect(() => {
         // TODO: Fetch actual pool balance from ShadowWire
         // For now, using placeholder
-        if (connected && shredrClient.initialized) {
+        if (connected && isInitialized && publicKey) {
             // Simulate fetching balance
+            setTotalBalance(100_000_000); // Placeholder balance
+        } else {
             setTotalBalance(0);
         }
-    }, [connected]);
+    }, [connected, isInitialized, publicKey]);
 
     // ============ ACTIONS ============
 
+    const handleUnlock = useCallback(async () => {
+        if (!publicKey || !signMessage) return;
+        try {
+            setIsUnlocking(true);
+            setWithdrawError(null);
+
+            const message = `SHREDR_V1:${publicKey.toBase58()}`;
+            const encodedMessage = new TextEncoder().encode(message);
+            const signature = await signMessage(encodedMessage);
+
+            const isNew = await shredrClient.checkIfNewUser(signature, publicKey.toBytes());
+            setIsNewUser(isNew);
+
+            if (!isNew) {
+                await shredrClient.initFromSignature(signature, publicKey.toBytes());
+                setIsInitialized(true);
+            }
+
+        } catch (err) {
+            console.error('Unlock failed:', err);
+            setWithdrawError('Failed to verify: ' + (err instanceof Error ? err.message : String(err)));
+        } finally {
+            setIsUnlocking(false);
+        }
+    }, [publicKey, signMessage]);
+
     const handleWithdraw = useCallback(async () => {
-        if (!destinationAddress) {
-            setWithdrawError('Please enter a destination address');
+        if (!publicKey || !shredrClient.currentBurner) {
+            setWithdrawError('Wallet not initialized');
             return;
         }
 
@@ -46,15 +78,11 @@ function ClaimPage({ onBack }: ClaimPageProps) {
             setWithdrawError(null);
             setWithdrawSuccess(null);
 
-            // TODO: Implement actual withdrawal via ShadowWire
-            // await shadowWireClient.withdraw(destinationAddress, totalBalance);
+            // TODO: Build Withdraw Transaction here
+            console.log("Withdraw initiated to", publicKey.toBase58());
 
-            // Simulate withdrawal
-            await new Promise(resolve => setTimeout(resolve, 2000));
-            
-            setWithdrawSuccess(`Successfully initiated private transfer of ${formatBalance(totalBalance)} SOL`);
-            setTotalBalance(0);
-            setDestinationAddress('');
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            setWithdrawSuccess("Withdraw initiated");
 
         } catch (err) {
             console.error('Withdrawal failed:', err);
@@ -62,29 +90,50 @@ function ClaimPage({ onBack }: ClaimPageProps) {
         } finally {
             setIsWithdrawing(false);
         }
-    }, [destinationAddress, totalBalance]);
+    }, [publicKey, totalBalance]);
 
     // ============ HELPERS ============
 
     const formatBalance = (lamports: number) => {
-        return (lamports / 1_000_000_000).toFixed(4);
+        return (lamports / LAMPORTS_PER_SOL).toFixed(4);
     };
 
     // ============ RENDER ============
 
-    if (!connected || !shredrClient.initialized) {
+    if (!connected) {
         return (
             <div className="claim-page">
                 <div className="claim-card">
-                    <div className="claim-header">
-                        <h1 className="claim-title">claim sol</h1>
+                    <div className="claim-header claim-header--centered">
+                        <h1 className="claim-title">withdraw sol</h1>
                     </div>
                     <div className="claim-message">
-                        Please connect wallet and unlock to view your balance
+                        Please connect wallet to continue
                     </div>
                     {onBack && (
                         <button className="back-btn" onClick={onBack}>
-                            ← back to generator
+                            ← back
+                        </button>
+                    )}
+                </div>
+            </div>
+        );
+    }
+
+    // Block new users - they need to generate an address first
+    if (isNewUser) {
+        return (
+            <div className="claim-page">
+                <div className="claim-card">
+                    <div className="claim-header claim-header--centered">
+                        <h1 className="claim-title">no funds found</h1>
+                    </div>
+                    <div className="claim-message">
+                        You haven't generated a privacy address yet. Please go to the Generate page first to create your address, then come back here after receiving funds.
+                    </div>
+                    {onBack && (
+                        <button className="back-btn" onClick={onBack}>
+                            ← go to generate
                         </button>
                     )}
                 </div>
@@ -96,7 +145,7 @@ function ClaimPage({ onBack }: ClaimPageProps) {
         <div className="claim-page">
             <div className="claim-card">
                 <div className="claim-header">
-                    <h1 className="claim-title">claim sol</h1>
+                    <h1 className="claim-title">withdraw sol</h1>
                     {onBack && (
                         <button className="back-link" onClick={onBack}>
                             ← back
@@ -106,21 +155,22 @@ function ClaimPage({ onBack }: ClaimPageProps) {
 
                 {/* Balance Display */}
                 <div className="balance-section">
-                    <span className="balance-label">total balance</span>
-                    <span className="balance-amount">{formatBalance(totalBalance)} SOL</span>
+                    <span className="balance-label">available balance</span>
+                    <span className="balance-amount">
+                        {isInitialized ? `${formatBalance(totalBalance)} SOL` : '---'}
+                    </span>
                 </div>
-
-                {/* Destination Input */}
-                <div className="destination-section">
-                    <label className="destination-label">destination address</label>
-                    <input
-                        type="text"
-                        className="destination-input"
-                        placeholder="Enter Solana address..."
-                        value={destinationAddress}
-                        onChange={(e) => setDestinationAddress(e.target.value)}
-                        disabled={isWithdrawing}
-                    />
+                
+                {isInitialized && (
+                    <div className="burner-address-display">
+                        <small>From: {shredrClient.currentBurnerAddress?.slice(0, 6)}...{shredrClient.currentBurnerAddress?.slice(-6)}</small>
+                    </div>
+                )}
+                
+                {/* Destination Display (Read Only) */}
+                <div className="destination-info">
+                   <div className="destination-label">Recieving Address</div>
+                   <div className="destination-value">{publicKey?.toBase58()}</div>
                 </div>
 
                 {/* Error Message */}
@@ -136,15 +186,19 @@ function ClaimPage({ onBack }: ClaimPageProps) {
                 {/* Withdraw Button */}
                 <button 
                     className="withdraw-btn"
-                    onClick={handleWithdraw}
-                    disabled={isWithdrawing || totalBalance <= 0}
+                    onClick={isInitialized ? handleWithdraw : handleUnlock}
+                    disabled={isWithdrawing || isUnlocking || (isInitialized && totalBalance <= 0)}
                 >
-                    {isWithdrawing ? 'processing...' : 'withdraw'}
+                    {isUnlocking ? 'verifying...' : 
+                     !isInitialized ? 'scan for funds' :
+                     isWithdrawing ? 'withdrawing...' : 'withdraw all'}
                 </button>
 
                 {/* Info Note */}
                 <div className="claim-note">
-                    Funds will be transferred privately via ShadowWire pool
+                    {!isInitialized 
+                        ? "Sign to recover your privacy keys and scan for funds." 
+                        : "Withdraw all funds to your connected wallet."}
                 </div>
             </div>
         </div>

--- a/tests/NonceService.test.ts
+++ b/tests/NonceService.test.ts
@@ -971,7 +971,7 @@ describe('NonceService', () => {
 
     after(() => {
         console.log('\n' + '='.repeat(50));
-        console.log('🎉 All NonceService tests completed!');
+        console.log('🎉 All tests completed!');
         console.log('='.repeat(50) + '\n');
     });
 });


### PR DESCRIPTION
## Summary by Sourcery

Update the claim/withdraw flow to use signed wallet messages for initialization, handle new-user cases, and align messaging and UI with a withdraw-all-to-wallet experience.

New Features:
- Add a wallet-based unlock flow that signs a message to recover privacy keys and scan for funds before allowing withdrawal.
- Introduce a new-user detection path that blocks withdrawals until a privacy address has been generated.

Bug Fixes:
- Fix the claim page to use the connected wallet as the fixed withdrawal destination instead of a manually entered address.
- Correct SOL balance formatting to use the canonical lamports-per-SOL constant.

Enhancements:
- Refine claim page copy and layout to present a withdraw-focused experience and clarify empty states and available balance.
- Expose burner address and receiving wallet address in read-only form for better transparency during withdrawals.
- Add a new-user flag to ShredrClient and a helper to detect existing users without full initialization, improving initialization logic and UX.
- Adjust generator signing to bind the master message to the specific wallet public key for better association.

Tests:
- Relax the NonceService test suite completion log message to apply to all tests, not just NonceService.