### PR TITLE
Update lodash and lodash-es to version 4.17.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5540,7 +5540,7 @@
         "@toruslabs/openlogin-jrpc": "^8.1.1",
         "eth-rpc-errors": "^4.0.3",
         "fast-deep-equal": "^3.1.3",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.17.23",
         "loglevel": "^1.9.1",
         "pump": "^3.0.0"
       },
@@ -6926,7 +6926,7 @@
         "@walletconnect/types": "2.19.0",
         "@walletconnect/utils": "2.19.0",
         "events": "3.3.0",
-        "lodash": "4.17.21"
+        "lodash": "4.17.23"
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/types": {
@@ -11049,14 +11049,14 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.22",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
       "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update package-lock.json to lock lodash and lodash-es to version 4.17.23.