### PR TITLE
fix: 🐛 fix function_call generateNonceAtIndex

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,9 @@
 name: "CodeQL Analysis"
-
 on:
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  schedule:
-    - cron: '30 1 * * 1'
 
 jobs:
   analyze:
@@ -20,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Use 'javascript-typescript' for TS and 'rust' for Rust
+        # We handle both in a single strategy
         language: [ 'javascript-typescript', 'rust' ]
 
     steps:
@@ -28,18 +25,16 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
-        # build-mode options: 'none' for TS, 'autobuild' or 'manual' for Rust
-        build-mode: ${{ matrix.language == 'rust' && 'autobuild' || 'none' }}
-
-    # Optional: Manual build step for Rust if autobuild fails
-    # - name: Manual Build
-    #   if: matrix.language == 'rust'
-    #   run: cargo build --release
+        # Set build-mode to 'none' for both. 
+        # This allows CodeQL to scan the source without running compiler commands.
+        build-mode: none
+        # Ensure CodeQL looks specifically into your backend folder for Rust
+        queries: security-extended,security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/shredr-backend/src/main.rs
+++ b/shredr-backend/src/main.rs
@@ -1,6 +1,6 @@
 mod db;
 mod webhook;
-mod websocket;
+// mod websocket;
 
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -9,7 +9,7 @@ use axum::{http::Request, routing::get, Router};
 use helius::{types::Cluster, Helius};
 use shuttle_axum::ShuttleAxum;
 use sqlx::PgPool;
-use tokio::sync::{watch, Mutex};
+// use tokio::sync::{watch, Mutex};
 use tower_governor::{
     governor::GovernorConfigBuilder,
     key_extractor::{KeyExtractor, PeerIpKeyExtractor},
@@ -19,7 +19,7 @@ use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 
 use db::{db_routes, AppState, DbHandler};
 use webhook::{webhook_routes, WebhookState};
-use websocket::{websocket_routes, WebSocketMessage, WebSocketState};
+// use websocket::{websocket_routes, WebSocketMessage, WebSocketState};
 
 /// Custom key extractor that reads client IP from forwarding headers,
 /// falling back to the default PeerIpKeyExtractor when none are present.
@@ -82,14 +82,14 @@ async fn main(
     tracing::info!("Database ready");
 
     // State
-    let (tx, rx) = watch::channel(WebSocketMessage::Status {
-        clients_count: 0,
-        timestamp: chrono::Utc::now(),
-    });
+    // let (tx, rx) = watch::channel(WebSocketMessage::Status {
+    //     clients_count: 0,
+    //     timestamp: chrono::Utc::now(),
+    // });
     let app_state = Arc::new(AppState { db: db_handler });
-    let ws_state = Arc::new(WebSocketState { clients_count: Arc::new(Mutex::new(0)), rx });
+    // let ws_state = Arc::new(WebSocketState { clients_count: Arc::new(Mutex::new(0)), rx });
     let helius = Arc::new(Helius::new(&helius_api_key, Cluster::MainnetBeta).expect("Helius init failed"));
-    let webhook_state = Arc::new(WebhookState { tx, helius });
+    let webhook_state = Arc::new(WebhookState { helius });
 
     // Rate limits
     let general_config = Arc::new(
@@ -140,7 +140,7 @@ async fn main(
         .merge(db_routes::create_router(app_state.clone()).layer(GovernorLayer::new(db_config)))
         .merge(db_routes::read_router(app_state).layer(GovernorLayer::new(general_config)))
         .merge(webhook_routes::router(webhook_state).layer(GovernorLayer::new(webhook_config)))
-        .merge(websocket_routes::router(ws_state))
+        // .merge(websocket_routes::router(ws_state))
         .route("/health", get(|| async { "OK" }))
         .layer(cors);
 

--- a/shredr-backend/src/webhook/webhook.rs
+++ b/shredr-backend/src/webhook/webhook.rs
@@ -7,11 +7,11 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::watch;
 
-use crate::websocket::WebSocketMessage;
+// use crate::websocket::WebSocketMessage;
 
 #[derive(Clone)]
 pub struct WebhookState {
-    pub tx: watch::Sender<WebSocketMessage>,
+    // pub tx: watch::Sender<WebSocketMessage>,
     pub helius: Arc<Helius>,
 }
 
@@ -126,38 +126,38 @@ pub async fn remove_address_handler(
     }
 }
 
-/// Helius webhook handler - receives Solana transaction notifications
-pub async fn helius_webhook_handler(
-    State(state): State<Arc<WebhookState>>,
-    Json(payload): Json<HeliusWebhookPayload>,
-) -> impl IntoResponse {
-    tracing::info!("Received Helius webhook: {:?}", payload);
+// Helius webhook handler - receives Solana transaction notifications
+// pub async fn helius_webhook_handler(
+//     State(state): State<Arc<WebhookState>>,
+//     Json(payload): Json<HeliusWebhookPayload>,
+// ) -> impl IntoResponse {
+//     tracing::info!("Received Helius webhook: {:?}", payload);
 
-    // Create WebSocket message from webhook data
-    let ws_message = WebSocketMessage::Transaction {
-        data: payload.data,
-        timestamp: chrono::Utc::now(),
-    };
+//     // Create WebSocket message from webhook data
+//     let ws_message = WebSocketMessage::Transaction {
+//         data: payload.data,
+//         timestamp: chrono::Utc::now(),
+//     };
 
-    // Broadcast to all connected WebSocket clients
-    match state.tx.send(ws_message) {
-        Ok(_) => {
-            tracing::info!("Successfully broadcast transaction to WebSocket clients");
-            (
-                StatusCode::OK,
-                Json(WebhookResponse {
-                    message: "Webhook received and broadcast".to_string(),
-                }),
-            )
-        }
-        Err(e) => {
-            tracing::error!("Failed to broadcast to WebSocket clients: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(WebhookResponse {
-                    message: format!("Failed to broadcast: {}", e),
-                }),
-            )
-        }
-    }
-}
+//     // Broadcast to all connected WebSocket clients
+//     match state.tx.send(ws_message) {
+//         Ok(_) => {
+//             tracing::info!("Successfully broadcast transaction to WebSocket clients");
+//             (
+//                 StatusCode::OK,
+//                 Json(WebhookResponse {
+//                     message: "Webhook received and broadcast".to_string(),
+//                 }),
+//             )
+//         }
+//         Err(e) => {
+//             tracing::error!("Failed to broadcast to WebSocket clients: {}", e);
+//             (
+//                 StatusCode::INTERNAL_SERVER_ERROR,
+//                 Json(WebhookResponse {
+//                     message: format!("Failed to broadcast: {}", e),
+//                 }),
+//             )
+//         }
+//     }
+// }

--- a/shredr-backend/src/webhook/webhook_routes.rs
+++ b/shredr-backend/src/webhook/webhook_routes.rs
@@ -2,14 +2,14 @@ use axum::{routing::post, Router};
 use std::sync::Arc;
 
 use super::webhook::{
-    add_address_handler, create_webhook_handler, helius_webhook_handler, remove_address_handler,
+    add_address_handler, create_webhook_handler, remove_address_handler,
     WebhookState,
 };
 
 /// Build webhook router
 pub fn router(state: Arc<WebhookState>) -> Router {
     Router::new()
-        .route("/webhook/helius", post(helius_webhook_handler))
+        // .route("/webhook/helius", post(helius_webhook_handler))
         .route("/webhook/create", post(create_webhook_handler))
         .route(
             "/webhook/address",

--- a/shredr-backend/src/websocket/mod.rs
+++ b/shredr-backend/src/websocket/mod.rs
@@ -1,4 +1,8 @@
+//Dead Module
+
 pub mod websocket;
 pub mod websocket_routes;
 
 pub use websocket::{WebSocketMessage, WebSocketState};
+
+

--- a/src/components/GeneratorCard/GeneratorCard.css
+++ b/src/components/GeneratorCard/GeneratorCard.css
@@ -48,6 +48,32 @@
     animation: fadeIn 0.3s ease;
 }
 
+/* ========== BALANCE DISPLAY ========== */
+.balance-display {
+    margin: 1.5rem 0;
+    padding: 1rem;
+    background: rgba(255, 26, 26, 0.05);
+    border: 1px solid rgba(255, 26, 26, 0.2);
+    border-radius: 4px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.balance-label {
+    font-size: 0.875rem;
+    color: #888;
+    text-transform: lowercase;
+    font-family: "Space Mono", monospace;
+}
+
+.balance-amount {
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: #ff1a1a;
+    font-family: "Space Mono", monospace;
+}
+
 /* ========== LOADING ANIMATION ========== */
 .loading-dots::after {
     content: '';

--- a/src/components/GeneratorCard/GeneratorCard.tsx
+++ b/src/components/GeneratorCard/GeneratorCard.tsx
@@ -93,6 +93,25 @@ function GeneratorCard() {
 
                 // 4. Connect WebSocket for transaction monitoring
                 webSocketClient.connect();
+
+                // 5. Subscribe to burner address once connected
+                if (webSocketClient.isConnected()) {
+                    webSocketClient.subscribeToAccount(address);
+                } else {
+                    const handleConnect = (connected: boolean) => {
+                        if (connected) {
+                            webSocketClient.subscribeToAccount(address);
+                            webSocketClient.offConnectionChange(handleConnect);
+                        }
+                    };
+                    webSocketClient.onConnectionChange(handleConnect);
+                }
+
+                // 6. Add message handler to console.log received messages
+                webSocketClient.onMessage((data) => {
+                    console.log('WebSocket message received:', data);
+                });
+              
             } else {
                 throw new Error('Failed to derive burner address');
             }

--- a/src/components/TransactionMonitor/TransactionMonitor.tsx
+++ b/src/components/TransactionMonitor/TransactionMonitor.tsx
@@ -5,6 +5,7 @@ import './TransactionMonitor.css';
 
 interface TransactionMonitorProps {
     burnerAddress: string;
+    externalTransactions?: TransactionInfo[];
 }
 
 interface TransactionInfo {
@@ -14,7 +15,7 @@ interface TransactionInfo {
     timestamp: string;
 }
 
-function TransactionMonitor({ burnerAddress }: TransactionMonitorProps) {
+function TransactionMonitor({ burnerAddress, externalTransactions = [] }: TransactionMonitorProps) {
     const [isConnected, setIsConnected] = useState(false);
     const [transactions, setTransactions] = useState<TransactionInfo[]>([]);
     const [lastActivity, setLastActivity] = useState<Date | null>(null);
@@ -57,6 +58,17 @@ function TransactionMonitor({ burnerAddress }: TransactionMonitorProps) {
             webSocketClient.offMessage(handleMessage);
         };
     }, [burnerAddress]);
+
+    // Merge external transactions
+    useEffect(() => {
+        if (externalTransactions.length > 0) {
+            setTransactions(prev => {
+                const combined = [...externalTransactions, ...prev];
+                return combined.slice(0, 10); // Keep last 10
+            });
+            setLastActivity(new Date());
+        }
+    }, [externalTransactions]);
 
     return (
         <div className="transaction-monitor">

--- a/src/lib/ShadowWireClient.ts
+++ b/src/lib/ShadowWireClient.ts
@@ -1,7 +1,7 @@
 import { ShadowWireClient as ShadowWireSDK, TokenUtils } from '@radr/shadowwire';
 import { Connection, Keypair, VersionedTransaction } from '@solana/web3.js';
 import nacl from 'tweetnacl';
-import { RPC_URL } from './constants';
+import { HELIUS_RPC_URL } from './constants';
 
 /**
  * ShadowWire wrapper class for Shredr
@@ -14,7 +14,7 @@ export class ShadowWireClient {
 
     constructor(rpcUrl?: string) {
         this.sdk = new ShadowWireSDK({ debug: true });
-        this.connection = new Connection(rpcUrl || RPC_URL);
+        this.connection = new Connection(rpcUrl || HELIUS_RPC_URL);
     }
 
     /**

--- a/src/lib/ShredrClient.ts
+++ b/src/lib/ShredrClient.ts
@@ -290,7 +290,7 @@ export class ShredrClient {
      * Get the balance at the Shadowire Address (burner[0])
      * This is the user's "private" balance available for withdrawal.
      * 
-     * @param rpcUrl - Solana RPC URL (defaults to VITE_RPC_URL env var or mainnet)
+     * @param rpcUrl - Solana RPC URL (defaults to HELIUS_RPC_URL env var or mainnet)
      */
     async getShadowireBalance(rpcUrl?: string): Promise<{
         available: number;         // SOL amount (human readable)
@@ -312,7 +312,7 @@ export class ShredrClient {
      * 
      * @param destinationAddress - The wallet address to send funds to
      * @param amountInSol - Amount to withdraw in SOL (use 'all' to withdraw everything)
-     * @param rpcUrl - Solana RPC URL (defaults to VITE_RPC_URL env var or mainnet)
+     * @param rpcUrl - Solana RPC URL (defaults to _RPC_URL env var or mainnet)
      */
     async withdrawToWallet(
         destinationAddress: string,

--- a/src/lib/WebSocketClient.ts
+++ b/src/lib/WebSocketClient.ts
@@ -31,7 +31,7 @@ export class WebSocketClient {
     connect(): void {
         if (this.ws?.readyState === WebSocket.OPEN) return;
 
-        // Change http://... to ws://... (your Cloudflare Worker URL)
+        // Cloudflare Worker URL
         console.log('Connecting to Proxy WS:', HELIUS_WSS_URL);
 
         this.ws = new WebSocket(HELIUS_WSS_URL);

--- a/src/lib/WebSocketClient.ts
+++ b/src/lib/WebSocketClient.ts
@@ -32,13 +32,21 @@ export class WebSocketClient {
         this.ws.onmessage = (event) => {
             try {
                 const data = JSON.parse(event.data);
-                
+
                 // Handle Solana account updates
                 if (data.method === "accountNotification") {
                     console.log("Account updated:", data.params.result.value);
                     const accountInfo = data.params.result.value;
                     if (accountInfo && typeof accountInfo.lamports === 'number') {
                         console.log(`New balance: ${accountInfo.lamports} lamports`);
+
+                        // Emit accountUpdate message with lamports
+                        const accountUpdateMessage = {
+                            type: 'accountUpdate',
+                            lamports: accountInfo.lamports,
+                            account: data.params.result.context.slot // or whatever identifier
+                        };
+                        this.messageHandlers.forEach(h => h(accountUpdateMessage));
                     }
                 }
 

--- a/src/lib/WebSocketClient.ts
+++ b/src/lib/WebSocketClient.ts
@@ -32,7 +32,17 @@ export class WebSocketClient {
         this.ws.onmessage = (event) => {
             try {
                 const data = JSON.parse(event.data);
-                // Solana updates come in as 'accountNotification'
+                
+                // Handle Solana account updates
+                if (data.method === "accountNotification") {
+                    console.log("Account updated:", data.params.result.value);
+                    const accountInfo = data.params.result.value;
+                    if (accountInfo && typeof accountInfo.lamports === 'number') {
+                        console.log(`New balance: ${accountInfo.lamports} lamports`);
+                    }
+                }
+
+                // Broadcast to all registered handlers
                 this.messageHandlers.forEach(h => h(data));
             } catch (e) {
                 console.error('WS Parse Error:', e);

--- a/src/lib/WebSocketClient.ts
+++ b/src/lib/WebSocketClient.ts
@@ -13,6 +13,19 @@ export class WebSocketClient {
     private connectionHandlers: ((connected: boolean) => void)[] = [];
 
     /**
+     * Sanitize data for safe logging
+     */
+    private sanitizeForLog(input: unknown): string {
+        let str: string;
+        if (typeof input === 'object' && input !== null) {
+            str = JSON.stringify(input);
+        } else {
+            str = `${input}`;
+        }
+        return str.replace(/[\r\n]/g, '');
+    }
+
+    /**
       * Connect to the Cloudflare Proxy
       */
     connect(): void {
@@ -35,10 +48,12 @@ export class WebSocketClient {
 
                 // Handle Solana account updates
                 if (data.method === "accountNotification") {
-                    console.log("Account updated:", data.params.result.value);
+                    const safeValue = this.sanitizeForLog(data.params.result.value);
+                    console.log("Account updated:", safeValue);
                     const accountInfo = data.params.result.value;
                     if (accountInfo && typeof accountInfo.lamports === 'number') {
-                        console.log(`New balance: ${accountInfo.lamports} lamports`);
+                        const safeLamports = this.sanitizeForLog(accountInfo.lamports);
+                        console.log(`New balance: ${safeLamports} lamports`);
 
                         // Emit accountUpdate message with lamports
                         const accountUpdateMessage = {

--- a/src/lib/WebSocketClient.ts
+++ b/src/lib/WebSocketClient.ts
@@ -1,4 +1,4 @@
-import { WebSocketMessage } from './types';
+import type { WebSocketMessage } from './types';
 import { API_BASE_URL } from './constants';
 
 /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -56,7 +56,11 @@ export const SALT_LENGTH = 16;
 /** PBKDF2 iteration count */
 export const PBKDF2_ITERATIONS = 100000;
 
-/** API Base URL */
+/** HELIUS RPC URL */
 export const HELIUS_RPC_URL = "https://rpc-proxy.shredrmoney.workers.dev";
-/** API Base URL */
+/** HELIUS WSS URL */
 export const HELIUS_WSS_URL = "wss://rpc-proxy.shredrmoney.workers.dev";
+/** API Base URL */
+export const API_BASE_URL = "http://localhost:8000";
+
+

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -41,10 +41,6 @@ export const DOMAIN_STORAGE_KEY = 'SHREDR_STORAGE_KEY';       // IndexedDB encry
 /** Domain separation for burner master seed derivation */
 export const DOMAIN_BURNER_MASTER = 'SHREDR_BURNER_MASTER';   // Master seed for burner derivation
 
-/** API Base URL */
-export const API_BASE_URL = 'http://localhost:8000';
-
-
 /** Number of consecutive empty addresses before stopping recovery scan */
 export const CONSECUTIVE_EMPTY_THRESHOLD = 10;
 
@@ -60,10 +56,7 @@ export const SALT_LENGTH = 16;
 /** PBKDF2 iteration count */
 export const PBKDF2_ITERATIONS = 100000;
 
-// ============ RPC CONSTANTS ============
-
-/** 
- * Solana RPC URL - loaded from VITE_RPC_URL environment variable 
- * Fallback to mainnet if not set
- */
-export const RPC_URL = import.meta.env.VITE_RPC_URL || 'https://api.mainnet-beta.solana.com';
+/** API Base URL */
+export const HELIUS_RPC_URL = "https://rpc-proxy.shredrmoney.workers.dev";
+/** API Base URL */
+export const HELIUS_WSS_URL = "wss://rpc-proxy.shredrmoney.workers.dev";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -151,7 +151,13 @@ export interface WebSocketStatusMessage {
     timestamp: string;  // ISO 8601 timestamp
 }
 
-export type WebSocketMessage = WebSocketTransactionMessage | WebSocketStatusMessage;
+export interface WebSocketAccountUpdateMessage {
+    type: 'accountUpdate';
+    lamports: number;
+    account: number;  // slot or some identifier
+}
+
+export type WebSocketMessage = WebSocketTransactionMessage | WebSocketStatusMessage | WebSocketAccountUpdateMessage;
 
 // ============ ERROR TYPES ============
 

--- a/src/pages/ClaimPage/ClaimPage.tsx
+++ b/src/pages/ClaimPage/ClaimPage.tsx
@@ -31,7 +31,7 @@ function ClaimPage({ onBack }: ClaimPageProps) {
         
         setIsLoadingBalance(true);
         try {
-            // Uses VITE_RPC_URL from env by default
+            // Uses HELIUS_RPC_URL from env by default
             const balance = await shredrClient.getShadowireBalance();
             setTotalBalance(balance.availableLamports);
         } catch (err) {
@@ -102,7 +102,7 @@ function ClaimPage({ onBack }: ClaimPageProps) {
             setWithdrawSuccess(null);
 
             // Withdraw via external transfer from Shadowire Address (burner[0]) to connected wallet
-            // Uses VITE_RPC_URL from env by default
+            // Uses HELIUS_RPC_URL from env by default
             const result = await shredrClient.withdrawToWallet(
                 publicKey.toBase58(),
                 'all'  // Withdraw full balance


### PR DESCRIPTION
## Summary by Sourcery

Update nonce generation logic, integrate direct Helius RPC/WebSocket usage for burner wallets, and surface burner balance and external activity in the UI while deprecating the custom WebSocket backend path.

New Features:
- Display live burner wallet SOL balance and recent significant incoming transactions in the generator UI and transaction monitor.
- Subscribe directly to Solana account updates via Helius WebSocket proxy for burner addresses.

Bug Fixes:
- Correct generateNonceAtIndex to derive nonces solely from the master seed with proper chaining while still binding them to the wallet hash metadata.

Enhancements:
- Route Solana JSON-RPC and WebSocket traffic through Cloudflare Helius proxy URLs and update ShadowWire client to use the new RPC endpoint.
- Extend WebSocket message typing to include account balance update messages and propagate them through the client.
- Simplify backend by disabling unused websocket and helius webhook routing/state wiring.

Documentation:
- Adjust comments and JSDoc to reference the new Helius RPC defaults instead of the previous environment-driven RPC URL.