### PR TITLE
fix :bug: fix rangeproof and dup constants

### DIFF
--- a/shredr-backend/.Dockerfile
+++ b/shredr-backend/.Dockerfile
@@ -1,0 +1,34 @@
+# Stage 1: Build
+FROM rust:1.84-slim-bookworm as builder
+
+WORKDIR /app
+
+# Install system dependencies (required for Solana/Crypto libs)
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    libudev-dev \
+    build-essential
+
+# Copy source
+COPY . .
+
+# Build release binary
+RUN cargo build --release
+
+# Stage 2: Runtime (Small, Clean)
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy binary from builder
+# REPLACE "shredr-backend" below with the actual name of your binary from Cargo.toml [package] name
+COPY --from=builder /app/target/release/shredr-backend /usr/local/bin/server
+
+CMD ["server"]

--- a/src/lib/ShredrClient.ts
+++ b/src/lib/ShredrClient.ts
@@ -12,7 +12,7 @@ import { burnerService } from "./BurnerService";
 import { apiClient } from "./ApiClient";
 import { ShadowWireClient } from "./ShadowWireClient";
 import { Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { SWEEP_FEE_BUFFER_LAMPORTS } from "./constants";
+import { SWEEP_FEE_BUFFER_LAMPORTS, SWEEP_THRESHOLD_LAMPORTS } from "./constants";
 import type { GeneratedNonce, BurnerKeyPair, CreateBlobRequest } from "./types";
 // ============ TYPES ============
 export type SigningMode = "auto" | "manual";
@@ -29,7 +29,7 @@ export interface IncomingTxResult {
   sweepSignature?: string;
 }
 
-export const MIN_SWEEP_THRESHOLD_LAMPORTS = 0.1 * LAMPORTS_PER_SOL;
+
 export interface ShredrState {
   initialized: boolean;
   currentNonce: GeneratedNonce | null;
@@ -366,7 +366,7 @@ export class ShredrClient {
     }
 
     // Check threshold
-    if (balanceLamports <= MIN_SWEEP_THRESHOLD_LAMPORTS) {
+    if (balanceLamports < SWEEP_THRESHOLD_LAMPORTS) {
       return { needsApproval: false };
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Validate WASM support and use dynamic amounts for range proof generation, and align sweep threshold logic with shared constants.

Bug Fixes:
- Use the actual transaction amount (in lamports) when generating range proofs instead of a hard-coded value.
- Unify sweep threshold comparison to use the shared SWEEP_THRESHOLD_LAMPORTS constant to avoid mismatched thresholds.

Enhancements:
- Introduce a reusable ensureWASM helper that validates WASM support and centralizes WASM initialization with clearer error messaging.